### PR TITLE
Исправлена проблема установки периода значением больше чем тип int

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ PWMrelay relay(пин);
 <a id="usage"></a>
 ## Использование
 ```cpp
-PWMrelay(int pin, bool dir = false, int period = 1000);	// пин, уровень реле HIGH/LOW, период
+PWMrelay(int pin, bool dir = false, unsigned long period = 1000);	// пин, уровень реле HIGH/LOW, период
 void tick();					// тик, вызывать как можно чаще, сам управляет реле
 void setPWM(byte duty);			// установить величину ШИМ, 0-255. При значении 0 и 255 тик неактивен!
 byte getPWM();					// возвращает величину ШИМ
-void setPeriod(int period);		// установить период ШИМ в миллисек. (по умолч. 1000мс == 1с)
+void setPeriod(unsigned long period);		// установить период ШИМ в миллисек. (по умолч. 1000мс == 1с)
 int getPeriod();				// получить период
 void setLevel(bool level);		// установить установить уровень реле (HIGH/LOW)
 ```
@@ -92,6 +92,7 @@ void loop() {
 <a id="versions"></a>
 ## Версии
 - v1.2 - исправлены мелкие ошибки с совместимостью
+- v1.2.1 - исправлена проблема установки периода значением больше чем тип int(32 767), т.е. теперь период можно устанавливать больше 32 сек.
 
 <a id="feedback"></a>
 ## Баги и обратная связь

--- a/README_EN.md
+++ b/README_EN.md
@@ -43,11 +43,11 @@ PWM relay(pin);
 <a id="usage"></a>
 ## Usage
 ```cpp
-PWMrelay(int pin, bool dir = false, int period = 1000); // pin, relay level HIGH/LOW, period
+PWMrelay(int pin, bool dir = false, unsigned long period = 1000); // pin, relay level HIGH/LOW, period
 void tick(); // tick, call as often as possible, controls the relay itself
 void setPWM(byte duty); // set the PWM value, 0-255. With a value of 0 and 255, the tick is inactive!
 byte getPWM(); // returns the PWM value
-void setPeriod(int period); // set the PWM period to milliseconds. (default 1000ms == 1s)
+void setPeriod(unsigned long period); // set the PWM period to milliseconds. (default 1000ms == 1s)
 int getPeriod(); // get period
 void setLevel(bool level); // set set relay level (HIGH/LOW)
 ```
@@ -82,6 +82,7 @@ void loop() {
 <a id="versions"></a>
 ## Versions
 - v1.2 - minor compatibility bugs fixed
+- v1.2.1 - fixed the problem of setting the period to a value greater than the type int(32,767), i.e. Now the period can be set to more than 32 seconds.
 
 <a id="feedback"></a>
 ## Bugs and feedback

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=PWMrelay
-version=1.2
+version=1.2.1
 author=AlexGyver <alex@alexgyver.ru>
 maintainer=AlexGyver <alex@alexgyver.ru>
 sentence=Low-frequency software PWM for relay

--- a/src/PWMrelay.cpp
+++ b/src/PWMrelay.cpp
@@ -1,6 +1,6 @@
 #include "PWMrelay.h"
 
-PWMrelay::PWMrelay(int pin, bool dir, int period) {
+PWMrelay::PWMrelay(int pin, bool dir, unsigned long period) {
     _pin = pin;
     _dir = !dir;
     pinMode(_pin, OUTPUT);
@@ -20,7 +20,7 @@ void PWMrelay::tick() {
 
 void PWMrelay::setPWM(byte duty) {
     _duty = duty;
-    _activePeriod = (long)_duty * _period / 255;
+    _activePeriod = _duty * (unsigned int)(_period / 255);
     if (_duty == 0) digitalWrite(_pin, _dir);		// выкл
     if (_duty == 255) digitalWrite(_pin, !_dir);	// вкл
 }
@@ -29,12 +29,12 @@ byte PWMrelay::getPWM() {
     return _duty;
 }
 
-void PWMrelay::setPeriod(int period) {
+void PWMrelay::setPeriod(unsigned long period) {
     _period = period;
     PWMrelay::setPWM(_duty);	// на случай "горячей" смены периода
 }
 
-int PWMrelay::getPeriod() {
+unsigned long PWMrelay::getPeriod() {
     return _period;
 }
 

--- a/src/PWMrelay.h
+++ b/src/PWMrelay.h
@@ -7,7 +7,7 @@
     - Настройка сигнала 0-255 (8 бит)
     - Поддержка реле низкого и высокого уровня
     - Неблокирующий вызов, не использует таймеры (кроме системного), работает на millis()
-    
+
     AlexGyver, alex@alexgyver.ru
     https://alexgyver.ru/
     MIT License
@@ -23,21 +23,21 @@
 
 class PWMrelay {
 public:
-    PWMrelay(int pin, bool dir = false, int period = 1000);	// пин, уровень реле HIGH/LOW, период
+    PWMrelay(int pin, bool dir = false, unsigned long period = 1000);	// пин, уровень реле HIGH/LOW, период
     void tick();					// тик, вызывать как можно чаще, сам управляет реле
     void setPWM(byte duty);			// установить величину ШИМ, 0-255. При значении 0 и 255 тик неактивен!
     byte getPWM();					// возвращает величину ШИМ
-    void setPeriod(int period);		// установить период ШИМ в миллисек. (по умолч. 1000мс == 1с)
-    int getPeriod();				// получить период
+    void setPeriod(unsigned long period);		// установить период ШИМ в миллисек. (по умолч. 1000мс == 1с)
+    unsigned long getPeriod();				// получить период
     void setLevel(bool level);		// установить установить уровень реле (HIGH/LOW)
-    
+
 private:
     bool _flag = false;
     bool _dir = false;
     byte _pin = 0;
     byte _duty = 0;
-    int _period = 1000;
-    int _activePeriod = 0;
+    unsigned long _period = 1000;
+    unsigned long _activePeriod = 0;
     uint32_t _tmr = 0;
 };
 #endif


### PR DESCRIPTION
Исправлена проблема установки периода значением больше чем тип int(32 767), т.е. теперь период можно устанавливать больше 32 сек.